### PR TITLE
Registro de associados simplificado + identificação de usuário via e-mail (backend)

### DIFF
--- a/app/members/templates/members/member_register.html
+++ b/app/members/templates/members/member_register.html
@@ -8,8 +8,7 @@
     <form action="" method="post" accept-charset="utf-8" class="form-horizontal">
         <fieldset>
             {% csrf_token %}
-                {{ user_form|as_bootstrap:"horizontal" }}
-                {{ member_form|as_bootstrap:"horizontal" }}
+                {{ form|as_bootstrap:"horizontal" }}
             <div class='form-actions'>
                 <button type="submit" class="btn btn-primary">Salvar</button>
             </div>

--- a/app/members/tests/helpers.py
+++ b/app/members/tests/helpers.py
@@ -4,16 +4,17 @@ from django.contrib.auth.models import User
 from app.members.models import Category, Member
 from django_dynamic_fixture import G
 
-def create_user(first_name, last_name, category=None):
+
+def create_user(email, first_name, last_name, category=None):
     category = category or Category.objects.get(id=1)
 
     user = User.objects.create_user(
         username='%s%s' % (first_name, last_name),
-        email='test@test.com',
+        email=email,
         password='pass'
     )
-    user.first_name=first_name
-    user.last_name=last_name
+    user.first_name = first_name
+    user.last_name = last_name
     user.save()
 
     G(Member, user=user, category=category)

--- a/app/members/views.py
+++ b/app/members/views.py
@@ -4,35 +4,33 @@ from datetime import datetime
 from django.contrib.auth.decorators import login_required
 from django.core.urlresolvers import reverse
 from django.utils.safestring import SafeUnicode
+from django.utils.translation import ugettext, ugettext_lazy as _
 
 from django.db.models import Q
+
+from django.http import HttpResponseRedirect
 from django.shortcuts import render
+
 from django.views.generic.list import ListView
 
 from django.contrib import messages
 
+from authemail.forms import RegisterForm
+
 from app.members.models import Member
-from app.members.forms import MemberForm, UserForm, UserEditionForm
+from app.members.forms import MemberForm, UserEditionForm
 
 
 def register(request):
-    member_form = MemberForm(request.POST or None)
-    user_form = UserForm(request.POST or None)
-
-    if request.method == 'POST' and user_form.is_valid() and member_form.is_valid():
-        user = user_form.save()
-        member = member_form.save(user)
-        login = reverse('auth-login')
-        messages.add_message(request, messages.INFO, SafeUnicode('Seu regitro foi realizado com sucesso. </br><a href="%s">Acesse seu perfil, para terminar de prencher se cadastro.</a>' % (login)))
-        #return HttpResponseRedirect(reverse('payment', kwargs={'member_id': member.id}))
-    else:
-        messages.add_message(request, messages.ERROR, 'Houve um problema no seu cadastro. Verifique os campos abaixo')
-    return render(request,
-        'members/member_register.html',
-            {
-            'user_form': user_form,
-            'member_form': member_form,
-            })
+    form = RegisterForm()
+    if request.method == 'POST':
+        #data = request.POST.copy()  # so we can manipulate data
+        form = RegisterForm(request.POST or None)
+        if form.is_valid():
+            form.save()
+            messages.success(request, _("Welcome ! You may login now."))
+            return HttpResponseRedirect(reverse('auth-login'))
+    return render(request, 'members/member_register.html', {'form': form})
 
 
 class MemberListView(ListView):

--- a/associados/settings.py
+++ b/associados/settings.py
@@ -163,6 +163,11 @@ INSTALLED_APPS = (
     'gravatar',
 )
 
+AUTHENTICATION_BACKENDS = (
+    'authemail.backends.EmailBackend',
+    'django.contrib.auth.backends.ModelBackend',
+ )
+
 # A sample logging configuration. The only tangible logging
 # performed by this configuration is to send an email to
 # the site admins on every HTTP 500 error when DEBUG=False.

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ django-gravatar==0.1.
 django-pipeline==1.2.11
 requests==0.13.3
 -e git+https://github.com/petry/django-bootstrap-toolkit.git@e7d01e86bc6b4ca7efebd2a97437489e6c583d12#egg=django_bootstrap_toolkit-dev
+git+git://github.com/cadu-leite/django-auth-email.git
 dj-database-url==0.2.1
 psycopg2==2.4.5
 gunicorn==0.14.6


### PR DESCRIPTION
fix #27 - registro só com email+senha
fix #28 - salva registro sem redirecionar para pagamento
fix #23 - daschboard do user.
- Added backend de autenticação no settings. 

Dependências:

1-django-auth-email -  https://github.com/cadu-leite/django-auth-email
