### PR TITLE
Remoção de dependências duplicadas

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,10 +1,8 @@
-Django==1.4
 coverage==3.5.2
 django-debug-toolbar==0.9.4
 django-dynamic-fixture==1.6.3
 django-extensions==0.9
 ipdb==0.6.1
 ipython==0.12.1
-sorl-thumbnail==11.12
 wsgiref==0.1.2
 django-nose==1.1

--- a/requirements_test_osx.txt
+++ b/requirements_test_osx.txt
@@ -1,4 +1,3 @@
-Django==1.4
 coverage==3.5.2
 django-debug-toolbar==0.9.4
 django-dynamic-fixture==1.6.3
@@ -6,6 +5,5 @@ django-extensions==0.9
 ipdb==0.6.1
 ipython==0.12.1
 readline==6.2.2
-sorl-thumbnail==11.12
 wsgiref==0.1.2
 django-nose==1.1


### PR DESCRIPTION
Removido as dependências que estavam duplicadas nos ambientes de produção e de teste. 

O problema encontrado foi que ao executar o script `setup_os.sh` por ter o Django em versões diferentes, acabava que ficava instalado a versão 1.4 no lugar da 1.4.2. Dessa forma é melhor manter o Django e os outros apps no `requirements.txt` somente.
