### PR TITLE
Correção do comando para enviar avisos de renovação por email

### DIFF
--- a/app/payment/management/commands/renewal_alert.py
+++ b/app/payment/management/commands/renewal_alert.py
@@ -48,6 +48,17 @@ class Command(BaseCommand):
         if settings.USE_I18N:
             translation.activate(settings.LANGUAGE_CODE)
         for payment in Payment.objects.filter(filter_arg):
+            last_payment = payment.member.get_last_payment()
+
+            if last_payment:
+                last_payment_date = last_payment.valid_until.date()
+                status = [last_payment_date > d for d in expiration_dates]
+                already_renewed = all(status)
+
+                # skip to send notification if already renewed
+                if already_renewed:
+                    continue
+
             valid_until_date = payment.valid_until.date()
             context = {
                 'contact_email': contact_email,

--- a/app/payment/tests/test_commands.py
+++ b/app/payment/tests/test_commands.py
@@ -13,7 +13,7 @@ from django.utils import timezone
 from django_dynamic_fixture import G
 
 from app.members.models import Member
-from app.payment.models import Payment, PaymentType
+from app.payment.models import Payment, PaymentType, Transaction
 
 
 class RenewalAlertTest(TestCase):
@@ -34,11 +34,11 @@ class RenewalAlertTest(TestCase):
 
         now = timezone.now()
         expiration_days = (30, 15, 7)
-        expiration_dates = [now - datetime.timedelta(days=d)
+        self.expiration_dates = [now - datetime.timedelta(days=d)
                             for d in expiration_days]
-        expiration_dates += [now]
+        self.expiration_dates += [now]
 
-        payment_type = PaymentType.objects.create(
+        self.payment_type = PaymentType.objects.create(
             category=self.members[0].category,
             price=50.0,
             duration=10
@@ -46,32 +46,85 @@ class RenewalAlertTest(TestCase):
 
         self.payments = [
             Payment.objects.create(member=self.members[0],
-                                   type=payment_type,
-                                   valid_until=expiration_dates[0]),
+                                   type=self.payment_type,
+                                   valid_until=self.expiration_dates[0]),
             Payment.objects.create(member=self.members[1],
-                                   type=payment_type,
-                                   valid_until=expiration_dates[1]),
+                                   type=self.payment_type,
+                                   valid_until=self.expiration_dates[1]),
             Payment.objects.create(member=self.members[2],
-                                   type=payment_type,
-                                   valid_until=expiration_dates[2]),
+                                   type=self.payment_type,
+                                   valid_until=self.expiration_dates[2]),
             Payment.objects.create(member=self.members[3],
-                                   type=payment_type,
-                                   valid_until=expiration_dates[3]),
+                                   type=self.payment_type,
+                                   valid_until=self.expiration_dates[3]),
         ]
 
         settings.EMAIL_CONTACT_ADDRESS = 'email@fake.com'
-        call_command('renewal_alert')
 
     def test_renewal_alert_send_emails(self):
+        call_command('renewal_alert')
+
         self.assertEqual(len(mail.outbox), 4)
 
     def test_renewal_alert_send_today_email(self):
+        call_command('renewal_alert')
+
         self.assertEqual(mail.outbox[3].subject, '[Associação Python Brasil] Anuidade vencida')
         self.assertIn(self.users[3].email, mail.outbox[3].to)
         self.assertTrue(mail.outbox[3].body.find(self.users[3].get_full_name()) != -1)
 
     def test_renewal_alert_send_other_days_email(self):
+        call_command('renewal_alert')
+
         for index, email in enumerate(mail.outbox[:3]):
             self.assertEqual(email.subject, '[Associação Python Brasil] Aviso de renovação')
             self.assertIn(self.users[index].email, email.to)
             self.assertTrue(email.body.find(self.users[index].get_full_name()) != -1)
+
+    def test_renewal_alert_not_send_email_when_already_renewed(self):
+        self.users += [
+            G(User),
+        ]
+
+        self.members += [
+            G(Member, user=self.users[4]),
+        ]
+
+        post_expiration_date = timezone.now() + datetime.timedelta(days=1)
+        delta = datetime.timedelta(days=self.payment_type.duration)
+        dates = [d - delta for d in self.expiration_dates + [post_expiration_date]]
+
+        self.payments += [
+            Payment.objects.create(member=self.members[4],
+                                   type=self.payment_type,
+                                   date=dates[0],
+                                   valid_until=self.expiration_dates[0]),
+            Payment.objects.create(member=self.members[4],
+                                   type=self.payment_type,
+                                   date=dates[1],
+                                   valid_until=self.expiration_dates[1]),
+            Payment.objects.create(member=self.members[4],
+                                   type=self.payment_type,
+                                   date=dates[2],
+                                   valid_until=self.expiration_dates[2]),
+            Payment.objects.create(member=self.members[4],
+                                   type=self.payment_type,
+                                   date=dates[3],
+                                   valid_until=self.expiration_dates[3]),
+            Payment.objects.create(member=self.members[4],
+                                   type=self.payment_type,
+                                   date=dates[4],
+                                   valid_until=post_expiration_date),
+        ]
+
+        G(Transaction, payment=self.payments[-5], status='3')
+        G(Transaction, payment=self.payments[-4], status='3')
+        G(Transaction, payment=self.payments[-3], status='3')
+        G(Transaction, payment=self.payments[-2], status='3')
+        G(Transaction, payment=self.payments[-1], status='3')
+
+        call_command('renewal_alert')
+
+        for email in mail.outbox:
+            self.assertNotIn(self.users[4].email, email.to)
+            self.assertFalse(email.body.find(self.users[4].get_full_name()) != -1)


### PR DESCRIPTION
Somente envia o aviso de renovação caso o membro ainda não tenha renovado sua assinatura. Relacionado a issue #87.
