### PR TITLE
Corrigir texto de localização no formulário de cadastro

### DIFF
--- a/associados/locale/pt_BR/LC_MESSAGES/django.po
+++ b/associados/locale/pt_BR/LC_MESSAGES/django.po
@@ -71,7 +71,7 @@ msgstr "Empresa"
 
 #: app/members/forms.py:53 app/members/models.py:61
 msgid "Location"
-msgstr "Localicação"
+msgstr "Localização"
 
 #: app/members/forms.py:72
 msgid "You can't change your category with pending payments"


### PR DESCRIPTION
Correção gramatical do texto "localicação" no formulário de cadastro de associados para "localização"