### PR TITLE
Diminui o acoplamento como Pagseguro

### DIFF
--- a/app/core/tests/test_flatpages.py
+++ b/app/core/tests/test_flatpages.py
@@ -28,7 +28,7 @@ class FlatpagesTest(TestCase):
 
     def test_should_render_the_title(self):
         dom = lhtml.fromstring(self.response.content)
-        self.assertEqual(dom.cssselect('title')[0].text, _('Python Brazil Association | ') + self.flatpage.title)
+        self.assertEqual(dom.cssselect('title')[0].text, _('Python Brazil Association') + ' | ' + self.flatpage.title)
 
     def test_should_have_the_member_form_route(self):
         url = reverse('members-signup')

--- a/app/members/tests/test_forms.py
+++ b/app/members/tests/test_forms.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python
 # encoding: utf-8
 from django.test import TestCase
+from django.utils.translation import ugettext as _
 from app.members.forms import MemberForm, UserForm
 from app.members.models import Organization, User, Category, Member
 from app.payment.models import Payment, PaymentType, Transaction
-from app.members.tests.helpers import create_user_with_member
 
 
 class UserFormTest(TestCase):
@@ -128,7 +128,7 @@ class ValidMemberFormTest(MemberFormTest):
         self.assertFalse(self.member_instance.get_payment_status())
         self.assertFalse(member_form.is_valid())
 
-        self.assertEqual(member_form.errors['category'], [u"You can't change your category with pending payments"])
+        self.assertEqual(member_form.errors['category'], [_(u"You can't change your category with pending payments")])
 
     def test_should_store_relation_with_community(self):
         self.assertEqual(self.member_instance.relation_with_community, self.data.get('relation_with_community'))

--- a/app/members/tests/test_view_update_member.py
+++ b/app/members/tests/test_view_update_member.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from django.core.urlresolvers import reverse, NoReverseMatch
 from django.test import TestCase
-from app.members.models import Member, Category, City, Organization
+from app.members.models import Member, Category, Organization
 from app.members.tests.helpers import create_user_with_member
 from lxml import html as lhtml
 
@@ -100,7 +100,8 @@ class MemberChangeWithErrorView(TestCase):
 
     def setUp(self):
         self.url = reverse('members-form')
-        self.user = create_user_with_member(first_name='test', last_name='fake')
+        self.user = create_user_with_member(first_name='test',
+                                            last_name='fake')
         self.client.login(username='testfake', password='pass')
         self.response = self.client.get(self.url)
         self.dom = lhtml.fromstring(self.response.content)

--- a/app/members/tests/test_view_update_member.py
+++ b/app/members/tests/test_view_update_member.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from django.core.urlresolvers import reverse, NoReverseMatch
 from django.test import TestCase
+from django.utils.translation import ugettext as _
 from app.members.models import Member, Category, Organization
 from app.members.tests.helpers import create_user_with_member
 from lxml import html as lhtml
@@ -117,4 +118,8 @@ class MemberChangeWithErrorView(TestCase):
 
     def test_post_with_correcly_data_should_update_a_member(self):
         response = self.client.post(self.url, self.data)
-        self.assertIn('An error occurred while trying to save your data. check the form below.', response.content)
+        self.assertIn(
+            _('An error occurred while trying to save your data.'
+              ' check the form below.'),
+            response.content.decode('utf-8')
+        )

--- a/app/payment/models.py
+++ b/app/payment/models.py
@@ -51,7 +51,7 @@ class Transaction(models.Model):
     price = models.DecimalField(max_digits=5, decimal_places=2)
 
     def get_checkout_url(self):
-        return settings.PAGSEGURO_WEBCHECKOUT + self.code
+        return settings.PAYMENT_CREDENTIALS_WEBCHECKOUT + self.code
 
     @property
     def status_display(self):

--- a/app/payment/models.py
+++ b/app/payment/models.py
@@ -57,7 +57,7 @@ class Transaction(models.Model):
     price = models.DecimalField(max_digits=5, decimal_places=2)
 
     def get_checkout_url(self):
-        return settings.PAYMENT_CREDENTIALS_WEBCHECKOUT + self.code
+        return settings.PAYMENT_ENDPOINT_WEBCHECKOUT + self.code
 
     @property
     def status_display(self):

--- a/app/payment/models.py
+++ b/app/payment/models.py
@@ -8,11 +8,15 @@ from django.utils import timezone
 from app.members.models import Member, Category
 
 
+PAID = '3'
+AVALIABLE = '4'
+
+
 TRANSACTION_STATUS = (
     ('1', u'Awaiting Payment'),
     ('2', u'In analysis'),
-    ('3', u'Paid'),
-    ('4', u'Available'),
+    (PAID, u'Paid'),
+    (AVALIABLE, u'Available'),
     ('5', u'In dispute'),
     ('6', u'Returned'),
     ('7', u'Cancelled'),
@@ -37,7 +41,9 @@ class Payment(models.Model):
     last_transaction = models.ForeignKey('Transaction', null=True, blank=True, related_name='last_transaction')
 
     def done(self):
-        return self.transaction_set.filter(status__in=[3, 4]).exists()
+        return self.transaction_set.filter(
+            status__in=[PAID, AVALIABLE]
+        ).exists()
 
     def __unicode__(self):
         return u'payment from {0}'.format(self.member)

--- a/app/payment/payment_class.py
+++ b/app/payment/payment_class.py
@@ -1,0 +1,46 @@
+import requests
+from django.conf import settings
+
+
+class PagSeguroCredentials(object):
+
+    def __init__(self):
+
+        PAYMENT_CREDENTIALS_BASE = settings.PAYMENT_CREDENTIALS_BASE
+        PAYMENT_CREDENTIALS_WEBCHECKOUT = (
+            settings.PAYMENT_CREDENTIALS_WEBCHECKOUT
+        )
+        PAYMENT_CREDENTIALS_PRE_APPROVAL = (
+            '%s/pre-approvals/request' % PAYMENT_CREDENTIALS_BASE
+        )
+
+        self.pre_approval = '%s/pre-approvals/request' \
+            % PAYMENT_CREDENTIALS_BASE
+        self.checkout = '%s/checkout' % PAYMENT_CREDENTIALS_BASE
+        self.transactions = '%s/transactions' % PAYMENT_CREDENTIALS_BASE
+        self.notifications = '%s/notifications' % self.transactions
+        self.web_checkout = PAYMENT_CREDENTIALS_WEBCHECKOUT
+        self.pre_approval = PAYMENT_CREDENTIALS_PRE_APPROVAL
+        self.web_pre_approval = settings.PAYMENT_CREDENTIALS_WEB_PRE_APPROVAL
+
+
+class PaymentClass(object):
+
+    def __init__(self, PAYMENT_SYSTEM=None, PAYMENT_CREDENTIALS=None):
+        self.payment_system = PAYMENT_SYSTEM or settings.PAYMENT_SYSTEM
+        self._set_payment_system()
+        self.payload = settings.PAYMENT_CREDENTIALS
+        self.headers = {"Content-Type":
+                        "application/x-www-form-urlencoded; charset=UTF-8"}
+
+    def get_payload(self):
+        return self.payload
+
+    def _set_payment_system(self):
+        if self.payment_system != 'PAGSEGURO':
+            return
+        self.credentials = PagSeguroCredentials()
+
+    def post(self, payload):
+        return requests.post(self.credentials.checkout, data=payload,
+                             headers=self.headers)

--- a/app/payment/payment_class.py
+++ b/app/payment/payment_class.py
@@ -33,14 +33,20 @@ class PaymentClass(object):
         self.headers = {"Content-Type":
                         "application/x-www-form-urlencoded; charset=UTF-8"}
 
-    def get_payload(self):
-        return self.payload
+    def set_price(self, price):
+        self.payload["itemAmount1"] = "%.2f" % price
+
+    def set_description(self, description):
+        self.payload['itemDescription1'] = description
+
+    def set_reference(self, payment):
+        self.payload["reference"] = "%d" % payment.pk
 
     def _set_payment_system(self):
         if self.payment_system != 'PAGSEGURO':
             return
         self.credentials = PagSeguroCredentials()
 
-    def post(self, payload):
-        return requests.post(self.credentials.checkout, data=payload,
+    def post(self):
+        return requests.post(self.credentials.checkout, data=self.payload,
                              headers=self.headers)

--- a/app/payment/payment_service.py
+++ b/app/payment/payment_service.py
@@ -1,5 +1,6 @@
 import requests
 from django.conf import settings
+from .models import PaymentType, Payment
 
 
 class PagSeguroCredentials(object):
@@ -50,3 +51,24 @@ class PaymentService(object):
     def post(self):
         return requests.post(self.credentials.checkout, data=self.payload,
                              headers=self.headers)
+
+    @classmethod
+    def get_member_payment(cls, member):
+        payment = Payment.objects.filter(
+            member=member,
+            type__category=member.category,
+            transaction__isnull=False,
+        ).last()
+
+        if payment is None:
+            payment_type = PaymentType.objects.get(category=member.category)
+            payment = Payment.objects.create(
+                member=member,
+                type=payment_type,
+            )
+
+        return payment
+
+
+
+        return payment

--- a/app/payment/payment_service.py
+++ b/app/payment/payment_service.py
@@ -31,8 +31,6 @@ class PaymentService(object):
         self.payment_system = PAYMENT_SYSTEM or settings.PAYMENT_SYSTEM
         self._set_payment_system()
         self.payload = settings.PAYMENT_CREDENTIALS
-        self.headers = {"Content-Type":
-                        "application/x-www-form-urlencoded; charset=UTF-8"}
 
     def set_price(self, price):
         self.payload["itemAmount1"] = "%.2f" % price
@@ -49,6 +47,7 @@ class PaymentService(object):
         self.credentials = PagSeguroCredentials()
 
     def post(self):
+        self._set_headers()
         return requests.post(self.credentials.checkout, data=self.payload,
                              headers=self.headers)
 
@@ -68,3 +67,7 @@ class PaymentService(object):
             )
 
         return payment
+
+    def _set_headers(self):
+        self.headers = {"Content-Type":
+                        "application/x-www-form-urlencoded; charset=UTF-8"}

--- a/app/payment/payment_service.py
+++ b/app/payment/payment_service.py
@@ -53,7 +53,11 @@ class PaymentService(object):
 
     def _set_payment_system(self):
         if self.payment_system != 'PAGSEGURO':
-            return
+            raise NotImplementedError(
+                'You must setup a matching Credentials object and '
+                'configure this function'
+            )
+
         self.credentials = PagSeguroCredentials()
 
     def post(self):

--- a/app/payment/payment_service.py
+++ b/app/payment/payment_service.py
@@ -68,7 +68,3 @@ class PaymentService(object):
             )
 
         return payment
-
-
-
-        return payment

--- a/app/payment/payment_service.py
+++ b/app/payment/payment_service.py
@@ -24,7 +24,7 @@ class PagSeguroCredentials(object):
         self.web_pre_approval = settings.PAYMENT_CREDENTIALS_WEB_PRE_APPROVAL
 
 
-class PaymentClass(object):
+class PaymentService(object):
 
     def __init__(self, PAYMENT_SYSTEM=None, PAYMENT_CREDENTIALS=None):
         self.payment_system = PAYMENT_SYSTEM or settings.PAYMENT_SYSTEM

--- a/app/payment/payment_service.py
+++ b/app/payment/payment_service.py
@@ -11,18 +11,18 @@ class PagSeguroCredentials(object):
 
     def __init__(self):
 
-        PAYMENT_ENDPOINT_BASE = settings.PAYMENT_CREDENTIALS_BASE
+        PAYMENT_ENDPOINTS_BASE = settings.PAYMENT_ENDPOINTS_BASE
         PAYMENT_ENDPOINT_WEBCHECKOUT = (
             settings.PAYMENT_ENDPOINT_WEBCHECKOUT
         )
         PAYMENT_ENDPOINT_PRE_APPROVAL = (
-            '%s/pre-approvals/request' % PAYMENT_ENDPOINT_BASE
+            '%s/pre-approvals/request' % PAYMENT_ENDPOINTS_BASE
         )
 
         self.pre_approval = '%s/pre-approvals/request' \
-            % PAYMENT_ENDPOINT_BASE
-        self.checkout = '%s/checkout' % PAYMENT_ENDPOINT_BASE
-        self.transactions = '%s/transactions' % PAYMENT_ENDPOINT_BASE
+            % PAYMENT_ENDPOINTS_BASE
+        self.checkout = '%s/checkout' % PAYMENT_ENDPOINTS_BASE
+        self.transactions = '%s/transactions' % PAYMENT_ENDPOINTS_BASE
         self.notifications = '%s/notifications' % self.transactions
         self.web_checkout = PAYMENT_ENDPOINT_WEBCHECKOUT
         self.pre_approval = PAYMENT_ENDPOINT_PRE_APPROVAL

--- a/app/payment/payment_service.py
+++ b/app/payment/payment_service.py
@@ -5,24 +5,28 @@ from .models import PaymentType, Payment
 
 class PagSeguroCredentials(object):
 
+    PRICE_PAYLOAD_ATTRIBUTE = "itemAmount1"
+    DESCRIPTION_PAYLOAD_ATTRIBUTE = "itemDescription1"
+    REFERENCE_ATTRIBUTE = "reference"
+
     def __init__(self):
 
-        PAYMENT_CREDENTIALS_BASE = settings.PAYMENT_CREDENTIALS_BASE
-        PAYMENT_CREDENTIALS_WEBCHECKOUT = (
-            settings.PAYMENT_CREDENTIALS_WEBCHECKOUT
+        PAYMENT_ENDPOINT_BASE = settings.PAYMENT_CREDENTIALS_BASE
+        PAYMENT_ENDPOINT_WEBCHECKOUT = (
+            settings.PAYMENT_ENDPOINT_WEBCHECKOUT
         )
-        PAYMENT_CREDENTIALS_PRE_APPROVAL = (
-            '%s/pre-approvals/request' % PAYMENT_CREDENTIALS_BASE
+        PAYMENT_ENDPOINT_PRE_APPROVAL = (
+            '%s/pre-approvals/request' % PAYMENT_ENDPOINT_BASE
         )
 
         self.pre_approval = '%s/pre-approvals/request' \
-            % PAYMENT_CREDENTIALS_BASE
-        self.checkout = '%s/checkout' % PAYMENT_CREDENTIALS_BASE
-        self.transactions = '%s/transactions' % PAYMENT_CREDENTIALS_BASE
+            % PAYMENT_ENDPOINT_BASE
+        self.checkout = '%s/checkout' % PAYMENT_ENDPOINT_BASE
+        self.transactions = '%s/transactions' % PAYMENT_ENDPOINT_BASE
         self.notifications = '%s/notifications' % self.transactions
-        self.web_checkout = PAYMENT_CREDENTIALS_WEBCHECKOUT
-        self.pre_approval = PAYMENT_CREDENTIALS_PRE_APPROVAL
-        self.web_pre_approval = settings.PAYMENT_CREDENTIALS_WEB_PRE_APPROVAL
+        self.web_checkout = PAYMENT_ENDPOINT_WEBCHECKOUT
+        self.pre_approval = PAYMENT_ENDPOINT_PRE_APPROVAL
+        self.web_pre_approval = settings.PAYMENT_ENDPOINT_WEB_PRE_APPROVAL
 
 
 class PaymentService(object):
@@ -33,13 +37,19 @@ class PaymentService(object):
         self.payload = settings.PAYMENT_CREDENTIALS
 
     def set_price(self, price):
-        self.payload["itemAmount1"] = "%.2f" % price
+        self.payload[
+            self.credentials.PRICE_PAYLOAD_ATTRIBUTE
+        ] = "%.2f" % price
 
     def set_description(self, description):
-        self.payload['itemDescription1'] = description
+        self.payload[
+            self.credentials.DESCRIPTION_PAYLOAD_ATTRIBUTE
+        ] = description
 
     def set_reference(self, payment):
-        self.payload["reference"] = "%d" % payment.pk
+        self.payload[
+            self.credentials.REFERENCE_ATTRIBUTE
+        ] = "%d" % payment.pk
 
     def _set_payment_system(self):
         if self.payment_system != 'PAGSEGURO':

--- a/app/payment/tests/test_model_transaction.py
+++ b/app/payment/tests/test_model_transaction.py
@@ -22,7 +22,7 @@ class TransacitonModelTestCase(TestCase):
 
     def test_get_checkout_url(self):
         t = Transaction(code="123")
-        expected_url = settings.PAGSEGURO_WEBCHECKOUT + "123"
+        expected_url = settings.PAYMENT_CREDENTIALS_WEBCHECKOUT + "123"
         self.assertEqual(expected_url, t.get_checkout_url())
 
     def assert_field_in(self, field_name, model):

--- a/app/payment/tests/test_model_transaction.py
+++ b/app/payment/tests/test_model_transaction.py
@@ -22,7 +22,7 @@ class TransacitonModelTestCase(TestCase):
 
     def test_get_checkout_url(self):
         t = Transaction(code="123")
-        expected_url = settings.PAYMENT_CREDENTIALS_WEBCHECKOUT + "123"
+        expected_url = settings.PAYMENT_ENDPOINT_WEBCHECKOUT + "123"
         self.assertEqual(expected_url, t.get_checkout_url())
 
     def assert_field_in(self, field_name, model):
@@ -44,4 +44,3 @@ class TransactionTestCase(TestCase):
             price='0.0'
         )
         self.assertEqual(transaction, payment.last_transaction)
-

--- a/app/payment/tests/test_payment_service.py
+++ b/app/payment/tests/test_payment_service.py
@@ -1,0 +1,80 @@
+# coding: utf-8
+import mock
+from django.test import TestCase
+
+from ..payment_service import PaymentService, PagSeguroCredentials
+
+
+class PaymentServiceTest(TestCase):
+
+    def setUp(self):
+        self.payment_service = PaymentService()
+
+    def test_payment_service_is_instantiated_with_default_config(self):
+        self.assertEqual(self.payment_service.payment_system, 'PAGSEGURO')
+        self.assertIsInstance(self.payment_service.credentials,
+                              PagSeguroCredentials)
+
+    def test_set_price_updates_payload(self):
+        self.payment_service.set_price(34)
+        self.assertIn(self.payment_service.credentials.PRICE_PAYLOAD_ATTRIBUTE,
+                      self.payment_service.payload)
+        self.assertEqual(
+            self.payment_service.payload[
+                self.payment_service.credentials.PRICE_PAYLOAD_ATTRIBUTE
+            ],
+            '34.00'
+        )
+
+    def test_set_description_updates_payload(self):
+        description = u'Associação Python Brasil'
+        self.payment_service.set_description(description)
+        self.assertIn(
+            self.payment_service.credentials.DESCRIPTION_PAYLOAD_ATTRIBUTE,
+            self.payment_service.payload
+        )
+        self.assertEqual(
+            self.payment_service.payload[
+                self.payment_service.credentials.DESCRIPTION_PAYLOAD_ATTRIBUTE
+            ],
+            description
+        )
+
+    def test_set_reference_updates_payload(self):
+        reference = 78798
+        payment = mock.Mock()
+        payment.pk = reference
+        self.payment_service.set_reference(payment)
+        self.assertIn(
+            self.payment_service.credentials.REFERENCE_ATTRIBUTE,
+            self.payment_service.payload
+        )
+        self.assertEqual(
+            self.payment_service.payload[
+                self.payment_service.credentials.REFERENCE_ATTRIBUTE
+            ],
+            str(reference)
+        )
+
+    def test_set_payment_system(self):
+        self.assertEquals(self.payment_service.payment_system, 'PAGSEGURO')
+        self.assertIsInstance(self.payment_service.credentials,
+                              PagSeguroCredentials)
+
+        self.payment_service.payment_system = 'AKAKJASD'
+        with self.assertRaises(NotImplementedError):
+            self.payment_service._set_payment_system()
+
+    @mock.patch('app.payment.payment_service.PaymentService._set_headers')
+    @mock.patch('app.payment.payment_service.requests.post')
+    def test_payment_service_post(self, mock_post, mock_set_headers):
+        ps = self.payment_service
+        ps.headers = '{}'
+        self.payment_service.post()
+        self.assertIsNone(mock_set_headers.assert_called_once_with())
+
+        self.assertIsNone(
+            mock_post.assert_called_once_with(
+                ps.credentials.checkout,
+                data=ps.payload, headers=ps.headers)
+        )

--- a/app/payment/tests/test_view.py
+++ b/app/payment/tests/test_view.py
@@ -96,7 +96,7 @@ class PaymentViewTestCase(MemberTestCase):
         response = PaymentView.as_view()(self.request, self.member.id)
         self.assertTrue(Payment.objects.filter(member=self.member).exists())
         self.assertEqual(302, response.status_code)
-        expected_url = settings.PAYMENT_CREDENTIALS_WEBCHECKOUT + "xpto123"
+        expected_url = settings.PAYMENT_ENDPOINT_WEBCHECKOUT + "xpto123"
         self.assertEqual(expected_url, response["Location"])
 
     def test_payment_view_should_create_a_payment_for_the_user_type(self):

--- a/app/payment/tests/test_view.py
+++ b/app/payment/tests/test_view.py
@@ -88,7 +88,7 @@ class PaymentViewTestCase(MemberTestCase):
         response = PaymentView.as_view()(self.request, self.member.id)
         self.assertTrue(Payment.objects.filter(member=self.member).exists())
         self.assertEqual(302, response.status_code)
-        expected_url = settings.PAGSEGURO_WEBCHECKOUT + "xpto123"
+        expected_url = settings.PAYMENT_CREDENTIALS_WEBCHECKOUT + "xpto123"
         self.assertEqual(expected_url, response["Location"])
 
     def test_payment_view_should_create_a_payment_for_the_user_type(self):

--- a/app/payment/tests/test_view.py
+++ b/app/payment/tests/test_view.py
@@ -54,6 +54,23 @@ class PaymentViewTestCase(MemberTestCase):
         views.requests = self.requests_original
         Payment.objects.all().delete()
 
+    def test_response_302(self):
+        resp = self._get_payment_endpoint()
+        self.assertEqual(302, resp.status_code)
+
+    def test_redirection_has_correct_url(self):
+        resp = self._get_payment_endpoint()
+        self.assertEqual(
+            'https://pagseguro.uol.com.br/v2/checkout/'
+            'payment.html?code=xpto123',
+            resp.url
+        )
+
+    @mock.patch('app.payment.views.get_object_or_404')
+    def _get_payment_endpoint(self, mock_get_404):
+        mock_get_404.return_value = self.member
+        return self.client.get(self.url)
+
     def test_payment_view_should_redirect_to_dashboard_if_it_fails_to_create_the_transaction(self):
         class ResponseMock(object):
             content = None

--- a/app/payment/tests/test_view.py
+++ b/app/payment/tests/test_view.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
+import mock
 from datetime import timedelta
 
 from django.conf import settings
 from django.contrib.auth.models import User
-from django.core.management import call_command
 from django.core.urlresolvers import reverse, NoReverseMatch
 from django.test import TestCase
 from django.test.client import RequestFactory
@@ -30,19 +30,10 @@ class MemberTestCase(TestCase):
 
 class PaymentViewTestCase(MemberTestCase):
 
-    @classmethod
-    def setUpClass(cls):
-        #call_command("loaddata", "profiles.json", verbosity=0)
-        pass
-
-    @classmethod
-    def tearDownClass(cls):
-        #call_command("flush", interactive=False, verbosity=0)
-        pass
-
     def setUp(self):
         super(PaymentViewTestCase, self).setUp()
 
+        self.url = reverse('payment', kwargs=dict(member_id=42))
         self.request = RequestFactory().get("/", {})
         self.request.user = self.user
 

--- a/app/payment/views.py
+++ b/app/payment/views.py
@@ -17,16 +17,17 @@ from django.utils.decorators import method_decorator
 from django.utils.translation import ugettext as _
 from django.views.decorators.csrf import csrf_exempt
 from django.views.generic import View
-from .payment_class import PaymentClass
 from app.members.models import Member
 from app.payment.models import Payment, Transaction, PaymentType
+
+from .payment_service import PaymentService
 
 
 logger = logging.getLogger(__name__)
 
 
 class PaymentView(View):
-    payment_class = PaymentClass
+    payment_class = PaymentService
 
     def _create_payload(self, payment, payment_obj):
         payment_obj.set_price(payment.type.price)

--- a/app/payment/views.py
+++ b/app/payment/views.py
@@ -29,17 +29,17 @@ logger = logging.getLogger(__name__)
 class PaymentView(View):
     payment_class = PaymentService
 
-    def _create_payload(self, payment, payment_obj):
-        payment_obj.set_price(payment.type.price)
-        payment_obj.set_description(
+    def _create_payload(self, payment, payment_service):
+        payment_service.set_price(payment.type.price)
+        payment_service.set_description(
             _(u'Brazilian Python Association registration payment')
         )
-        payment_obj.set_reference(payment)
+        payment_service.set_reference(payment)
 
     def set_payment_code(self, payment):
-        payment_obj = self.get_payment_service()
-        self._create_payload(payment, payment_obj)
-        response = payment_obj.post()
+        payment_service = self.get_payment_service()
+        self._create_payload(payment, payment_service)
+        response = payment_service.post()
         if response.ok:
             dom = lhtml.fromstring(response.content)
             transaction_code = dom.xpath("//code")[0].text

--- a/app/payment/views.py
+++ b/app/payment/views.py
@@ -49,11 +49,8 @@ class PaymentView(View):
 
     def get(self, request, member_id):
         member = get_object_or_404(Member, pk=member_id)
-        payment_type = PaymentType.objects.get(category=member.category)
-        payment = Payment.objects.create(
-            member=member,
-            type=payment_type
-        )
+        payment_service = self.get_payment_object()
+        payment = payment_service.get_member_payment(member)
         payment_with_code = self.set_payment_code(payment)
 
         if not payment_with_code.code:

--- a/app/payment/views.py
+++ b/app/payment/views.py
@@ -61,7 +61,7 @@ class PaymentView(View):
                 "Please contact the staff to complete your registration."),
                            fail_silently=True)
         else:
-            url = settings.PAYMENT_CREDENTIALS_WEBCHECKOUT \
+            url = settings.PAYMENT_ENDPOINT_WEBCHECKOUT \
                 + payment_with_code.code
         return HttpResponseRedirect(url)
 
@@ -70,19 +70,23 @@ class PaymentView(View):
 
 
 class NotificationView(View):
+    payment_class = PaymentService
+
     def __init__(self, **kwargs):
         self.transaction_code = None
         super(NotificationView, self).__init__(**kwargs)
 
     def transaction(self, transaction_code):
+        payment_service = self.get_payment_service()
+
         url_transacao = "%s/%s?email=%s&token=%s" % (
-            settings.PAYMENT_CREDENTIALS_TRANSACTIONS,
+            payment_service.credentials.transactions,
             transaction_code,
             settings.PAYMENT_CREDENTIALS["email"],
             settings.PAYMENT_CREDENTIALS["token"]
         )
         url_notificacao = "%s/%s?email=%s&token=%s" % (
-            settings.PAYMENT_CREDENTIALS_TRANSACTIONS_NOTIFICATIONS,
+            payment_service.credentials.notifications,
             transaction_code,
             settings.PAYMENT_CREDENTIALS["email"],
             settings.PAYMENT_CREDENTIALS["token"]
@@ -157,3 +161,6 @@ class NotificationView(View):
                                     self.transaction_code)
 
         return HttpResponse("OK")
+
+    def get_payment_service(self):
+        return self.payment_class()

--- a/associados/settings.py
+++ b/associados/settings.py
@@ -230,33 +230,37 @@ DEFAULT_FROM_EMAIL = decouple.config('DEFAULT_FROM_EMAIL',
 EMAIL_CONTACT_ADDRESS = DEFAULT_FROM_EMAIL
 
 # 3rd party applications
-PAGSEGURO = {
-    'email': decouple.config('PAGSEGURO_EMAIL', default=''),
+
+PAYMENT_SYSTEM = decouple.config('PAYMENT_SYSTEM', default="PAGSEGURO")
+
+PAYMENT_CREDENTIALS = {
+    'email': decouple.config('PAYMENT_CREDENTIALS_EMAIL'),
     'charset': 'UTF-8',
-    'token': decouple.config('PAGSEGURO_TOKEN', default=''),
+    'token': decouple.config('PAYMENT_CREDENTIALS_TOKEN'),
     'currency': 'BRL',
     'itemId1': '0001',
     'itemQuantity1': 1,
 }
 
-PAGSEGURO_BASE = decouple.config('PAGSEGURO_BASE',
-                                 default='https://ws.pagseguro.uol.com.br/v2')
-
-PAGSEGURO_WEBCHECKOUT = decouple.config(
-    'PAGSEGURO_WEBCHECKOUT',
+PAYMENT_CREDENTIALS_BASE = decouple.config(
+    'PAYMENT_CREDENTIALS_BASE',
+    default='https://ws.pagseguro.uol.com.br/v2'
+)
+PAYMENT_CREDENTIALS_WEBCHECKOUT = decouple.config(
+    'PAYMENT_CREDENTIALS_WEBCHECKOUT',
     default='https://pagseguro.uol.com.br/v2/checkout/payment.html?code='
 )
-
-PAGSEGURO_WEB_PRE_APPROVAL = decouple.config(
-    'PAGSEGURO_WEB_PRE_APPROVAL',
+PAYMENT_CREDENTIALS_WEB_PRE_APPROVAL = decouple.config(
+    'PAYMENT_CREDENTIALS_PRE_APPROVAL',
     default='https://pagseguro.uol.com.br/v2/pre-approval/request.html?code='
 )
-
-PAGSEGURO_PRE_APPROVAL = '%s/pre-approvals/request' % PAGSEGURO_BASE
-PAGSEGURO_CHECKOUT = '%s/checkout' % PAGSEGURO_BASE
-PAGSEGURO_TRANSACTIONS = '%s/transactions' % PAGSEGURO_BASE
-PAGSEGURO_TRANSACTIONS_NOTIFICATIONS = (
-    '%s/notifications' % PAGSEGURO_TRANSACTIONS
+PAYMENT_CREDENTIALS_CHECKOUT = '%s/checkout' % PAYMENT_CREDENTIALS_BASE
+PAYMENT_CREDENTIALS_TRANSACTIONS = '%s/transactions' % PAYMENT_CREDENTIALS_BASE
+PAYMENT_CREDENTIALS_TRANSACTIONS_NOTIFICATIONS = (
+    '%s/notifications' % PAYMENT_CREDENTIALS_TRANSACTIONS
+)
+PAYMENT_CREDENTIALS_PRE_APPROVAL = (
+    '%s/pre-approvals/request' % PAYMENT_CREDENTIALS_BASE
 )
 
 GITHUB_CLIENT_SECRET = decouple.config('GITHUB_CLIENT_SECRET', default='')

--- a/associados/settings.py
+++ b/associados/settings.py
@@ -158,7 +158,7 @@ MIDDLEWARE_CLASSES = (
 
 # Apps
 INSTALLED_APPS = (
-    #apps
+    # apps
     'associados',
     'app.members',
     'app.payment',
@@ -174,7 +174,7 @@ INSTALLED_APPS = (
     'django.contrib.admindocs',
     'django.contrib.flatpages',
 
-    #extra
+    # extra
     'bootstrap_toolkit',
     'pipeline',
     'django_extensions',

--- a/associados/settings.py
+++ b/associados/settings.py
@@ -242,25 +242,17 @@ PAYMENT_CREDENTIALS = {
     'itemQuantity1': 1,
 }
 
-PAYMENT_CREDENTIALS_BASE = decouple.config(
+PAYMENT_ENDPOINTS_BASE = decouple.config(
     'PAYMENT_CREDENTIALS_BASE',
     default='https://ws.pagseguro.uol.com.br/v2'
 )
-PAYMENT_CREDENTIALS_WEBCHECKOUT = decouple.config(
+PAYMENT_ENDPOINT_WEBCHECKOUT = decouple.config(
     'PAYMENT_CREDENTIALS_WEBCHECKOUT',
     default='https://pagseguro.uol.com.br/v2/checkout/payment.html?code='
 )
-PAYMENT_CREDENTIALS_WEB_PRE_APPROVAL = decouple.config(
+PAYMENT_ENDPOINT_WEB_PRE_APPROVAL = decouple.config(
     'PAYMENT_CREDENTIALS_PRE_APPROVAL',
     default='https://pagseguro.uol.com.br/v2/pre-approval/request.html?code='
-)
-PAYMENT_CREDENTIALS_CHECKOUT = '%s/checkout' % PAYMENT_CREDENTIALS_BASE
-PAYMENT_CREDENTIALS_TRANSACTIONS = '%s/transactions' % PAYMENT_CREDENTIALS_BASE
-PAYMENT_CREDENTIALS_TRANSACTIONS_NOTIFICATIONS = (
-    '%s/notifications' % PAYMENT_CREDENTIALS_TRANSACTIONS
-)
-PAYMENT_CREDENTIALS_PRE_APPROVAL = (
-    '%s/pre-approvals/request' % PAYMENT_CREDENTIALS_BASE
 )
 
 GITHUB_CLIENT_SECRET = decouple.config('GITHUB_CLIENT_SECRET', default='')

--- a/associados/settings.py
+++ b/associados/settings.py
@@ -234,9 +234,10 @@ EMAIL_CONTACT_ADDRESS = DEFAULT_FROM_EMAIL
 PAYMENT_SYSTEM = decouple.config('PAYMENT_SYSTEM', default="PAGSEGURO")
 
 PAYMENT_CREDENTIALS = {
-    'email': decouple.config('PAYMENT_CREDENTIALS_EMAIL'),
+    'email': decouple.config('PAYMENT_CREDENTIALS_EMAIL',
+                             default='fake@email.com'),
     'charset': 'UTF-8',
-    'token': decouple.config('PAYMENT_CREDENTIALS_TOKEN'),
+    'token': decouple.config('PAYMENT_CREDENTIALS_TOKEN', default='faketoken'),
     'currency': 'BRL',
     'itemId1': '0001',
     'itemQuantity1': 1,
@@ -247,11 +248,11 @@ PAYMENT_ENDPOINTS_BASE = decouple.config(
     default='https://ws.pagseguro.uol.com.br/v2'
 )
 PAYMENT_ENDPOINT_WEBCHECKOUT = decouple.config(
-    'PAYMENT_CREDENTIALS_WEBCHECKOUT',
+    'PAYMENT_ENDPOINT_WEBCHECKOUT',
     default='https://pagseguro.uol.com.br/v2/checkout/payment.html?code='
 )
 PAYMENT_ENDPOINT_WEB_PRE_APPROVAL = decouple.config(
-    'PAYMENT_CREDENTIALS_PRE_APPROVAL',
+    'PAYMENT_ENDPOINT_WEB_PRE_APPROVAL',
     default='https://pagseguro.uol.com.br/v2/pre-approval/request.html?code='
 )
 

--- a/associados/settings_local_model.py
+++ b/associados/settings_local_model.py
@@ -52,15 +52,15 @@ EMAIL_FILE_PATH = '/tmp/lead-messages'  # change this to a proper location
 
 EMAIL_CONTACT_ADDRESS = 'email@fake.com'
 
-PAGSEGURO['email'] = 'email@fake.com'
-PAGSEGURO['token'] = 'faketoken'
+PAYMENT_CREDENTIALS['email'] = 'email@fake.com'
+PAYMENT_CREDENTIALS['token'] = 'faketoken'
 
 #using pagseguro-fake-server: https://github.com/andrewsmedina/pagseguro-fake-server
-PAGSEGURO_BASE = 'http://localhost:8889/v2'
-PAGSEGURO_CHECKOUT = '%s/checkout' % PAGSEGURO_BASE
-PAGSEGURO_TRANSACTIONS = '%s/transactions' % PAGSEGURO_BASE
-PAGSEGURO_TRANSACTIONS_NOTIFICATIONS = '%s/notifications' % PAGSEGURO_TRANSACTIONS
-PAGSEGURO_WEBCHECKOUT = 'https://pagseguro.uol.com.br/v2/checkout/payment.html?code='
+PAYMENT_CREDENTIALS_BASE = 'http://localhost:8889/v2'
+PAYMENT_CREDENTIALS_CHECKOUT = '%s/checkout' % PAYMENT_CREDENTIALS_BASE
+PAYMENT_CREDENTIALS_TRANSACTIONS = '%s/transactions' % PAYMENT_CREDENTIALS_BASE
+PAYMENT_CREDENTIALS_TRANSACTIONS_NOTIFICATIONS = '%s/notifications' % PAYMENT_CREDENTIALS_TRANSACTIONS
+PAYMENT_CREDENTIALS_WEBCHECKOUT = 'https://pagseguro.uol.com.br/v2/checkout/payment.html?code='
 
 
 MEDIA_ROOT = os.path.join(BASEDIR, 'media')

--- a/associados/urls.py
+++ b/associados/urls.py
@@ -2,17 +2,18 @@ from django.conf import settings
 from django.conf.urls import patterns, include, url
 from django.contrib import admin
 from django.contrib.staticfiles.urls import staticfiles_urlpatterns
+from app.payment import urls as payment_urls
 
 admin.autodiscover()
 
 urlpatterns = patterns(
     '',
     url(r'^members/', include('app.members.urls')),
-    url(r'^payment/', include('app.payment.urls')),
+    url(r'^payment/', include(payment_urls)),
     url(r'^admin/doc/', include('django.contrib.admindocs.urls')),
     url(r'^admin/', include(admin.site.urls)),
-    url(r'^', include('django.contrib.auth.urls')),
     url(r'^municipios_app/', include('municipios.urls')),
+    url(r'^', include('django.contrib.auth.urls')),
 )
 
 if settings.DEBUG:

--- a/cover.sh
+++ b/cover.sh
@@ -9,7 +9,7 @@ rm .coverage
 PARMS=--omit='*migrations*'
 
 # run the tests and collect coverage, only for our applications
-coverage run manage.py test --settings=associados.settings_test
+coverage run --omit=.venv/* manage.py test --settings=associados.settings_test
 
 # generate plaintext and HTML report
 echo "----------------------------"

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,2 +1,3 @@
 -r requirements_test_osx.txt
 wsgiref==0.1.2
+mock==2.0.0


### PR DESCRIPTION
Esse patch cria um payment_service para desacoplar o PAGSEGURO da view de pagamento (#146).
O ideal seria já ter algum outro gateway de pagamento em mente para testar a  configuração de outro serviço. 