### PR TITLE
Corrige o erro ao chamar a função last_transaction_name

### DIFF
--- a/app/payment/admin.py
+++ b/app/payment/admin.py
@@ -23,7 +23,9 @@ make_paid.short_description = _("Set last transactions as paid")
 
 
 def last_transaction_name(obj):
-    return obj.last_transaction.get_status_display()
+	if obj.last_transaction:
+		return obj.last_transaction.get_status_display()
+	return ''
 
 
 last_transaction_name.short_description = _('Last Transaction')


### PR DESCRIPTION
Se o campo `last_transaction` não tiver nenhum valor no objeto passado por parâmetro, retorna uma string vazia.