### PR TITLE
Implementar Docker-Compose para ambiente local

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ htmlcov/*
 associados.sqlite
 test.py
 
+# Docker generated files
+src/
+docker/db/pgdata/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:2.7
+
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+COPY requirements_test.txt /usr/src/app/
+COPY requirements_test_osx.txt /usr/src/app/
+COPY requirements.txt /usr/src/app/
+RUN pip install -r requirements_test.txt

--- a/README.md
+++ b/README.md
@@ -59,6 +59,22 @@ Rodando os testes
     $ make test
 
 
+Ambiente com Docker
+---------------------------
+
+Caso queira subir o ambiente com Docker, temos um `docker-compose.yml` com o PostgreSQL e o Django. No arquivo, também é possível alterar as informações de acesso do PostgreSQL.
+
+Instalar o [Docker/Docker-Compose](https://docs.docker.com/engine/installation/).
+
+Copiar o arquivo `associados/example_settings.ini` para `associados/settings.ini` e configurar as variáveis locais.
+
+Copiar o arquivo `associados/settings_local.py` para `associados/settings_local_model.py` e configurar a variável do banco de dados.
+
+Subir o ambiente com o comando `docker-compose.yml`.
+
+Caso queria realizar os testes, usar o comando `docker-compose run web python manage.py test --settings associados.settings_test --verbosity=2`.
+
+
 Como contribuir?
 ----------------
 

--- a/check_db.py
+++ b/check_db.py
@@ -1,0 +1,28 @@
+import socket
+import time
+import argparse
+""" Check if port is open, avoid docker-compose race condition """
+
+parser = argparse.ArgumentParser(description='Check if port is open, avoid\
+                                 docker-compose race condition')
+parser.add_argument('--service-name', required=True)
+parser.add_argument('--ip', required=True)
+parser.add_argument('--port', required=True)
+
+args = parser.parse_args()
+
+# Get arguments
+service_name = str(args.service_name)
+port = int(args.port)
+ip = str(args.ip)
+
+# Infinite loop
+while True:
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    result = sock.connect_ex((ip, port))
+    if result == 0:
+        print("{0} port is open! Bye!".format(service_name))
+        break
+    else:
+        print("{0} port is not open! I'll check it soon!".format(service_name))
+        time.sleep(3)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,26 @@
+version: '2'
+services:
+
+  db:
+    image: postgres:9.4
+    ports:
+      - "5432:5432"
+    volumes:
+      - "./docker/db/pgdata:/var/lib/postgresql/data"
+    environment:
+      POSTGRES_PASSWORD: assocdev
+      POSTGRES_USER: associados
+      POSTGRES_DB: associados
+
+  web:
+    build: .
+    command: bash -c "python check_db.py --service-name Postgres --ip db --port 5432 &&
+                      python manage.py migrate --settings associados.settings && 
+                      python manage.py loaddata --settings associados.settings app/core/fixtures/site_init.json &&
+                      python manage.py runserver 0.0.0.0:8000 --settings associados.settings_local"
+    ports:
+      - "8000:8000"
+    depends_on:
+      - db
+    volumes:
+      - ".:/usr/src/app"


### PR DESCRIPTION
Código para tratar #171 .

Como funciona:
* `docker-compose.yml` para subir dois containers separados (PostgreSQL e Django).
* `Dockerfile` para buildar a imagem necessária do Python/Django.
* `check_db.py` script para garantir que o Django suba somente depois do banco.

Testei com OSX Capitain e Docker 1.12.