### PR TITLE
Atualiza docker e requirements.txt

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:2.7
+FROM python:3.6.9
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
@@ -6,4 +6,5 @@ WORKDIR /usr/src/app
 COPY requirements_test.txt /usr/src/app/
 COPY requirements_test_osx.txt /usr/src/app/
 COPY requirements.txt /usr/src/app/
-RUN pip install -r requirements_test.txt
+RUN pip install --no-cache-dir --upgrade pip \
+    && pip install --no-cache-dir -r requirements_test.txt

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,8 +15,8 @@ services:
   web:
     build: .
     command: bash -c "python check_db.py --service-name Postgres --ip db --port 5432 &&
-                      python manage.py migrate --settings associados.settings && 
-                      python manage.py loaddata --settings associados.settings app/core/fixtures/site_init.json &&
+                      python manage.py migrate --settings associados.settings_local &&
+                      python manage.py loaddata --settings associados.settings_local app/core/fixtures/site_init.json &&
                       python manage.py runserver 0.0.0.0:8000 --settings associados.settings_local"
     ports:
       - "8000:8000"

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,12 +4,12 @@ sorl-thumbnail==12.3
 django-gravatar2==1.4.0
 django-pipeline==1.6.9
 requests==2.11.1
--e git+https://github.com/pythonbrasil/django-bootstrap-toolkit.git@v1-associados#egg=django_bootstrap_toolkit-dev
+git+https://github.com/pythonbrasil/django-bootstrap-toolkit.git@v1-associados#egg=django_bootstrap_toolkit
 dj-database-url==0.3.0
 psycopg2-binary==2.7.7
 gunicorn==19.6.0
 lxml==4.4.1
--e git+https://github.com/pythonbrasil/django-s3-folder-storage.git@d7e8b7939b554e8fdc6815da5fa349bf7d5d8aaa#egg=django_s3_folder_storage
+git+https://github.com/pythonbrasil/django-s3-folder-storage.git@d7e8b7939b554e8fdc6815da5fa349bf7d5d8aaa#egg=django_s3_folder_storage
 #South==0.7.6
 slumber==0.7.1
 python-decouple==3.0


### PR DESCRIPTION
## Descrição
Este PR tem como propósito resolver o problema da instalação dos módulos `django-bootstrap-toolkit`e `django-s3-folder-storage`, que não estão sendo reconhecidos em uma instalação zerada do Docker. Retirando a instalação dos módulos em modo edição (parâmetro "-e") funciona sem problemas.
Também atualiza a versão Python do Dockerfile para a versão do *runtime* da aplicação, adiciona
comando para atualizar o pip antes de instalar os requirements e corrige os comandos do serviço `web` do compose.

Closes #191 