### PR TITLE
Atualiza configuração para rodar a aplicação com docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,3 +29,6 @@ makemessages:
 
 compilemessages:
 	@python manage.py compilemessages
+
+run-with-docker:
+	docker-compose run --service-ports --rm web

--- a/README.md
+++ b/README.md
@@ -64,15 +64,15 @@ Ambiente com Docker
 
 Caso queira subir o ambiente com Docker, temos um `docker-compose.yml` com o PostgreSQL e o Django. No arquivo, também é possível alterar as informações de acesso do PostgreSQL.
 
-Instalar o [Docker/Docker-Compose](https://docs.docker.com/engine/installation/).
+Instalar o [Docker](https://docs.docker.com/engine/installation/) e o [Docker-Compose](https://docs.docker.com/compose/install/).
 
-Copiar o arquivo `associados/example_settings.ini` para `associados/settings.ini` e configurar as variáveis locais.
+Primeiramente vamos buildar nossos serviços `web` e `db` com o comando `docker-compose build`. Quando finalizar, estaremos prontos para rodar os primeiros comandos usando o `bin/run` como atalho.
 
-Copiar o arquivo `associados/settings_local.py` para `associados/settings_local_model.py` e configurar a variável do banco de dados.
+- Para rodar o `migrate`: `./bin/run python manage.py migrate`
+- Para carregar nossas fixtures com o `loaddata`: `./bin/run python manage.py loaddata app/core/fixtures/site_init.json`
+- E por fim para rodar o servidor de desenvolvimento Django, você só precisa deste comando: `make run-with-docker`. Esse comando vai levantar nosso servidor juntamente com as dependências de qualquer outro serviço (no nosso caso, `db`)
 
-Subir o ambiente com o comando `docker-compose.yml`.
-
-Caso queria realizar os testes, usar o comando `docker-compose run web python manage.py test --settings associados.settings_test --verbosity=2`.
+Caso queria realizar os testes, usar o comando `./bin/run python manage.py test --settings associados.settings_test --verbosity=2`.
 
 
 Como contribuir?

--- a/bin/run
+++ b/bin/run
@@ -1,0 +1,2 @@
+#!/bin/bash
+docker-compose run --rm web $@

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,9 +11,7 @@ services:
 
   web:
     build: ./
-    command: bash -c "python manage.py migrate &&
-                      python manage.py loaddata app/core/fixtures/site_init.json &&
-                      python manage.py runserver 0.0.0.0:8000"
+    command: python manage.py runserver 0.0.0.0:8000
     ports:
       - "8000:8000"
     depends_on:

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,5 +19,4 @@ six==1.10.0
 raven==5.27.1
 django-localflavor==1.3
 cssselect==0.9.2
-#django-municipios==0.8.1
--e git+https://github.com/lskbr/django-municipios.git#egg=django-municipios
+django-municipios==1.2.1


### PR DESCRIPTION
Tive uma série de problemas ao tentar rodar a aplicação usando Docker. Com ajuda do @emyller vimos algumas melhorias que tornaram a configuração mais simples (apesar da separação de alguns comandos). Seguem os comandos para rodar o projeto localmente com Docker:

- `./bin/run python manage.py migrate`
- `./bin/run python manage.py loaddata app/core/fixtures/site_init.json`
- `make run-with-docker`