### PR TITLE
Simplifica dependências e instação

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.6.9
 # Unbuffer Python logs
 ENV PYTHONUNBUFFERED=1
 
-COPY requirements_test.txt requirements_test_osx.txt requirements.txt /tmp/
+COPY requirements_test.txt requirements.txt /tmp/
 RUN pip install --upgrade pip && pip install -r /tmp/requirements_test.txt
 
 RUN mkdir -p /usr/src/app

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ O projeto é desenvolvido por voluntários, utilizando principamente Python e Dj
 Preparando o ambiente
 ---------------------
 
-Recomenda-se utilizar o [virtualenv](http://docs.python-guide.org/en/latest/dev/virtualenvs/) para manter o ambiente isolado de suas aplicações. Testado com Python 3.5.2, Postgresql 9.5.4 e Django 1.10.1.
+Recomenda-se utilizar o [virtualenv](http://docs.python-guide.org/en/latest/dev/virtualenvs/) para manter o ambiente isolado de suas aplicações. Testado com Python 3.6.9, Postgresql 9.5.4 e Django 1.11.29.
 
 
 Você precisa instalar o postgresql em sua máquina antes de continuar.

--- a/app/payment/tests/test_payment_service.py
+++ b/app/payment/tests/test_payment_service.py
@@ -1,5 +1,6 @@
 # coding: utf-8
-import mock
+from unittest import mock
+
 from django.test import TestCase
 
 from ..payment_service import PaymentService, PagSeguroCredentials

--- a/app/payment/tests/test_view.py
+++ b/app/payment/tests/test_view.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-import mock
+from unittest import mock
+
 from datetime import timedelta
 
 from django.conf import settings

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,2 +1,5 @@
--r requirements_test_osx.txt
-mock==2.0.0
+-r requirements.txt
+coverage==4.2
+model_bakery==1.1.0
+ipdb==0.10.1
+ipython==5.1.0

--- a/requirements_test_osx.txt
+++ b/requirements_test_osx.txt
@@ -1,5 +1,0 @@
--r requirements.txt
-coverage==4.2
-model_bakery==1.1.0
-ipdb==0.10.1
-ipython==5.1.0

--- a/setup_os.sh
+++ b/setup_os.sh
@@ -9,7 +9,7 @@ if [[ $OSTYPE == 'linux-gnu' ]]; then
 elif [[ $OSTYPE == darwin* ]]; then
     echo 'OSX: Instalando dependencias...'
     sleep 3
-    pip install -r requirements_test_osx.txt
+    pip install -r requirements_test.txt
 fi
 
 FILE="./associados/settings_local.py"


### PR DESCRIPTION
Com base na pergunta #225 sugiro removermos a dependência externa `mock`. Como usamos Python mais novo que 3.3 [não faz sentido ter essa dependência](https://pypi.org/project/mock/). Com isso, temos dois efeitos:

* não restam diferenças entre `requirements_test_osx.txt` e `requirements_test.txt`, portanto eliminei o primeiro
* atualizei os arquivos trocando `import mock` pela opção nativa `form unittest import mock`

E, ao longo dessas micro-mudanças, reparei que as versões pinadas (do Django `requirements.txt` e do Python no `Dockerife`) não conferiam com a do `README.md` — aí atualizei isso também.