### PR TITLE
Checa se o status é Available para o caso de pagamento em PIX

### DIFF
--- a/app/members/templates/members/dashboard.html
+++ b/app/members/templates/members/dashboard.html
@@ -55,7 +55,7 @@
                     {% if user.member.category.name == "Estudante" %}
                       <tr>
                           <th span="2">
-                              <a class="btn btn-success" href="{% url 'payments:update-category' %}">
+                              <a class="btn btn-success" href="{% url 'members:update-category' %}">
                                   <i class="icon-shopping-cart icon-white"></i>Mudar categoria para efetivo
                               </a>
                           </th>

--- a/app/payment/tests/test_view.py
+++ b/app/payment/tests/test_view.py
@@ -12,7 +12,7 @@ from django.core import mail
 
 from app.members.models import Member, Category
 from app.payment import views
-from app.payment.models import Payment, Transaction, PaymentType
+from app.payment.models import Payment, Transaction, PaymentType, AVALIABLE
 from app.payment.views import PaymentView, NotificationView
 
 
@@ -248,6 +248,22 @@ class NotificationViewTestCase(MemberTestCase):
         payment, transaction = self._make_transaction(status=1, code="xpto", price='123.45')
         notification_view = NotificationView()
         notification_view.transaction = (lambda code: (3, payment.id, transaction.price))
+        request = RequestFactory().post("/", {"notificationCode": "xpto"})
+
+        response = notification_view.post(request)
+
+        transaction = Transaction.objects.get(id=transaction.id)
+
+    def test_post_with_status_available_should_return_payment_done(self):
+        payment, transaction = self._make_transaction(
+            status=1,
+            code="xpto",
+            price='123.45',
+        )
+        notification_view = NotificationView()
+        notification_view.transaction = (
+            lambda code: (AVALIABLE, payment.id, transaction.price)
+        )
         request = RequestFactory().post("/", {"notificationCode": "xpto"})
 
         response = notification_view.post(request)

--- a/app/payment/views.py
+++ b/app/payment/views.py
@@ -17,7 +17,12 @@ from django.utils.translation import ugettext as _
 from django.views.decorators.csrf import csrf_exempt
 from django.views.generic import View
 from app.members.models import Member
-from app.payment.models import Payment, Transaction
+from app.payment.models import (
+    AVALIABLE,
+    PAID,
+    Payment,
+    Transaction,
+)
 
 from .payment_service import PaymentService
 
@@ -154,7 +159,7 @@ class NotificationView(View):
             if status is None or payment_id is None or price is None:
                 return HttpResponseBadRequest("Error processing transaction")
 
-            if status == 3:
+            if status in [AVALIABLE, PAID]:
                 self.transaction_done(payment_id)
             self.create_transaction(payment_id, status, price,
                                     self.transaction_code)


### PR DESCRIPTION
Para pagamento em PIX, o retorno status da transaction vai ser `4` (Available) ao invés de `3` (Paid). Por essa razão, alguns users que estavam pagando a anuidade não estavam tendo sua transaction marcada como [done](https://github.com/pythonbrasil/associados/blob/master/app/payment/views.py#L158). Acredito que esse seja o fix para o problema (apesar da documentação do PagSeguro ser bem.... desafiadora.

Se esse de fato resolver o problema, vamos ter que encontrar uma maneira de marcar essa transaction como done para as pessoas que realizaram o pagamento e continuam com a anuidade constando como não paga.

Alguns links/referências sobre como encontrei a possível solução

- https://dev.pagseguro.uol.com.br/discuss/61671c97ac36ea004f8382bf
- https://documenter.getpostman.com/view/10863174/TVetc6HV#209355ec-a9d4-4228-8c6d-81e0db11002a
- https://github.com/pagseguro/pagseguro-sdk-php/issues/218#issuecomment-758861904
- https://dev.pagseguro.uol.com.br/reference/charge-webhook

Se me permitem, estou incluindo nesse PR o fix para essa issue: https://sentry.io/organizations/associados-4c/issues/2887464634/?environment=production&project=1799053&query=is%3Aunresolved

Para quem não tiver acesso, estou incluindo screenshot: 
![image](https://user-images.githubusercontent.com/1661112/147862038-8102beab-2d97-4fc8-8d8e-7e72e3b28a4b.png)
